### PR TITLE
Update the URL used to download this Gerrit-CLI script

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@
 - In order to use script **gerrit-cli.sh** anywhere within your Shell terminal, you need to put it into the System path.
 ```shell
 mkdir $HOME/.bin
-curl -Lo $HOME/.bin/gerrit-cli.sh https://raw.githubusercontent.com/BlankLiu/Gerrit-CLI/master/gerrit-cli.sh
+curl -Lo $HOME/.bin/gerrit-cli.sh https://raw.githubusercontent.com/blankliu/Gerrit-CLI/master/gerrit-cli.sh
+chmod a+x $HOME/.bin/gerrit-cli.sh
 sudo ln -sf $HOME/.bin/gerrit-cli.sh /usr/bin/gerrit-cli.sh
 ```
 


### PR DESCRIPTION
1. Due to username update, URL of Gerrit-CLI script needs to be updated
   as well, otherwise it may not be found if someone else uses the old
   username and same project name by accident.
2. Make the script executable after getting it downloaded locally.