### PR TITLE
Wrap Gerrit command ls-user-refs

### DIFF
--- a/gerrit-cli.sh
+++ b/gerrit-cli.sh
@@ -6,6 +6,9 @@ ERROR_CODE_CONFIG_NOT_FOUND=1
 ERROR_CODE_SSH_KEY_NOT_MATCH=2
 ERROR_CODE_COMMAND_NOT_SUPPORTED=3
 ERROR_CODE_BRANCH_CREATION_FAILURE=4
+ERROR_CODE_EXCLUSIVE_OPTIONS_PROVIDED=5
+ERROR_CODE_GERRIT_USER_NOT_FOUND=6
+ERROR_CODE_PROJECT_NOT_FOUND=7
 
 declare -A CMD_USAGE_MAPPING
 declare -A CMD_OPTION_MAPPING
@@ -177,16 +180,143 @@ function __create_branch() {
     return $_RET_VALUE
 }
 
+function __print_usage_of_ls_user_refs() {
+    local _RET_VALUE=
+
+    _RET_VALUE=0
+    cat << EOU
+SYNOPSIS
+    1. gerrit-cli.sh ls-user-refs -p <PROJECT> -u <USER> [-b] [-t]
+
+DESCRIPTION
+    Display all refs (branches and tags) that the specified user can access.
+
+    Options -b|--branch-only and -t|--tag-only are exclusive.
+
+OPTIONS
+    -p|--project <PROJECT>
+        Specify project's name.
+
+    -u|--user <USER>
+        Specify a user's name.
+
+    -b|--branch-only
+        Only show branches under reference refs/heads.
+
+    -t|--tag-only
+        Only show tags under reference refs/tags.
+
+    -h|--help
+        Show this usage document.
+
+EXAMPLES
+    1. List all visible refs for user 'blankl' in project 'release/jenkins'
+       $ gerrit-cli.sh ls-users-refs -p release/jenkins -u blankl
+
+    2. List all visible tags for user 'blankl' in project 'release/jenkins'
+       $ gerrit-cli.sh ls-users-refs -p release/jenkins -u blankl -t
+EOU
+
+    return $_RET_VALUE
+}
+
+function __ls_user_refs() {
+    local _SUB_CMD=
+    local _ARGS=
+    local _PROJECT=
+    local _USER=
+    local _BRANCH_ONLY=
+    local _TAG_ONLY=
+    local _CLI_CMD=
+    local _TMPFILE=
+    local _RET_VALUE=
+
+    _SUB_CMD="ls-user-refs"
+    _BRANCH_ONLY="false"
+    _TAG_ONLY="false"
+    _RET_VALUE=0
+
+    if [[ $# -eq 0 ]]; then
+        eval "${CMD_USAGE_MAPPING[$_SUB_CMD]}"
+        return $_RET_VALUE
+    fi
+
+    _ARGS=$(getopt ${CMD_OPTION_MAPPING[$_SUB_CMD]} -- $@)
+    eval set -- "$_ARGS"
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -p|--project)
+                _PROJECT=$2
+                ;;
+            -u|--user)
+                _USER=$2
+                ;;
+            -b|--branch-only)
+                _BRANCH_ONLY="true"
+                ;;
+            -t|--tag-only)
+                _TAG_ONLY="true"
+                ;;
+            -h|--help)
+                eval ${CMD_USAGE_MAPPING[$_SUB_CMD]}
+                return $_RET_VALUE
+                ;;
+            --)
+                shift
+                break
+                ;;
+        esac
+        shift
+    done
+
+    if eval "$_BRANCH_ONLY" && eval "$_TAG_ONLY"; then
+        _RET_VALUE=$ERROR_CODE_EXCLUSIVE_OPTIONS_PROVIDED
+        log_e "options -b|--branch-only and -t|--tag-only are exclusive."
+    else
+        _TMPFILE=$(tempfile -s ".refs")
+        _CLI_CMD="$GERRIT_CLI $_SUB_CMD -p $_PROJECT -u $_USER > $_TMPFILE"
+        if eval "$_CLI_CMD"; then
+            if grep -q "$_USER" "$_TMPFILE"; then
+                _RET_VALUE=$ERROR_CODE_GERRIT_USER_NOT_FOUND
+                xargs -a "$_TMPFILE" echo "fatal:"
+            else
+                if eval "$_BRANCH_ONLY"; then
+                    cat "$_TMPFILE" | grep "refs/heads/.*" | sort
+                elif eval "$_TAG_ONLY"; then
+                    cat "$_TMPFILE" | grep "refs/tags/.*" | sort
+                else
+                    cat "$_TMPFILE" | grep -E "refs/(heads|tags)/.*" | sort
+                fi
+            fi
+        else
+            _RET_VALUE=$ERROR_CODE_PROJECT_NOT_FOUND
+            cat "$_TMPFILE"
+        fi
+
+        if [ ! -s "$_TMPFILE" ]; then
+            log_i "user '$_USER' has no permission on project '$_PROJECT'"
+        fi
+
+        rm -f "$_TMPFILE"
+    fi
+
+    return $_RET_VALUE
+}
+
 function __init_command_context() {
     # Maps sub-command to its usage
     CMD_USAGE_MAPPING["create-branch"]="__print_usage_of_create_branch"
+    CMD_USAGE_MAPPING["ls-user-refs"]="__print_usage_of_ls_user_refs"
 
     # Maps sub-command to its options
     CMD_OPTION_MAPPING["create-branch"]="-o p:b:r:f:\
         -l project:,branch:,revision:,file:"
+    CMD_OPTION_MAPPING["ls-user-refs"]="-o p:u:bth\
+        -l project:,user:,branch-only,tag-only,help"
 
     # Maps sub-command to the implementation of its function
     CMD_FUNCTION_MAPPING["create-branch"]="__create_branch"
+    CMD_FUNCTION_MAPPING["ls-user-refs"]="__ls_user_refs"
 }
 
 function __print_cli_usage() {
@@ -197,6 +327,8 @@ These are sub-commands wrapped in the script. Each one has a corresponding
 Gerrit command whose official document can be found wihin a Gerrit release.
 1. create-branch
    Creates a new branch for a project.
+2. ls-user-refs
+   Lists all refs (branches and tags) accessible for a specified user.
 
 To show usage of a <SUB_COMMAND>, use following command:
    gerrit-cli.sh help <SUB_COMMAND>


### PR DESCRIPTION
Default Gerrit command ls-user-refs lists all references a specified
user can see, including branches, tags and changes.
However, in this Gerrit CLI script, only branches and tags will be
showed. This is because Gerrit changes depend on branches for existence.